### PR TITLE
Stringify the env variable before inlining so it's a string.

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ var config = {
         // Make NODE_ENV accessible from within client scripts (for conditional dev/prod builds).
         new webpack.DefinePlugin({
             'process.env': {
-                'NODE_ENV': process.env.NODE_ENV
+                'NODE_ENV': JSON.stringify(process.env.NODE_ENV)
             }
         }),
 


### PR DESCRIPTION
#### Changes
Fixes a problem with the DefinePlugin where it would inline an environment variable as plain-ol' text and cause "variable not defined" errors. By stringifying the environment variable first, we can make sure we inline it as a string.

---

For review: @deadlybutter 