### PR TITLE
Allowing jpg|jpeg and both woff|woff2 in file test for using loader.

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ var config = {
             { test: /\.js$/, exclude: /node_modules/, loader: 'babel' },
 
             // Bundle static assets, either hashing filename or inlining into bundle if under 8KB
-            { test: /\.(png|jpg|eot|gif|woff|svg|ttf)$/, loader: 'url?limit=8192' },
+            { test: /\.(png|jpe?g|eot|gif|woff2?|svg|ttf)$/, loader: 'url?limit=8192' },
 
             // Bundle CSS stylesheets and process with PostCSS, extract to single CSS file per bundle.
             { test: /\.css$/, loader: ExtractTextPlugin.extract('css?sourceMap!postcss') },


### PR DESCRIPTION
Quick update to the regex for the test to use the `url-loader` so it now includes `jpeg` with the `e` and `woff2`.