### PR TITLE
Always hash asset filenames & add Lodash webpack plugin.

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@
 
 var webpack = require('webpack');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
+var ManifestPlugin = require('webpack-manifest-plugin');
 var defaults = require('lodash/defaultsDeep');
 var assign = require('lodash/assign');
 var path = require('path');
@@ -15,7 +16,7 @@ var config = {
         // ...
     },
     output: {
-        filename: '[name].js',
+        filename: '[name]-[hash].js',
         path: 'dist',
         libraryTarget: 'umd',
     },
@@ -54,8 +55,15 @@ var config = {
         }),
 
         // Extract all stylesheets referenced in each bundle into a single CSS file.
-        new ExtractTextPlugin('[name].css'),
-        // ...
+        new ExtractTextPlugin('[name]-[hash].css'),
+      
+        // Optimize ordering of modules for better minification
+        new webpack.optimize.OccurrenceOrderPlugin,
+
+        // Create asset manifest (allowing Laravel or other apps to get hashed asset names).
+        new ManifestPlugin({
+          fileName: 'rev-manifest.json',
+        }),
     ]
 };
 

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@
 
 var webpack = require('webpack');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
+var LodashModuleReplacementPlugin = require('lodash-webpack-plugin');
 var ManifestPlugin = require('webpack-manifest-plugin');
 var defaults = require('lodash/defaultsDeep');
 var assign = require('lodash/assign');
@@ -59,6 +60,9 @@ var config = {
       
         // Optimize ordering of modules for better minification
         new webpack.optimize.OccurrenceOrderPlugin,
+
+        // Optimize Lodash references for smaller builds.
+        new LodashModuleReplacementPlugin,
 
         // Create asset manifest (allowing Laravel or other apps to get hashed asset names).
         new ManifestPlugin({

--- a/package.json
+++ b/package.json
@@ -21,9 +21,11 @@
     "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.8.5",
     "lodash": "^4.6.1",
+    "lodash-webpack-plugin": "^0.11.2",
     "node-sass": "^3.4.2",
     "postcss-loader": "^0.8.2",
     "sass-loader": "^3.2.0",
-    "url-loader": "^0.5.7"
+    "url-loader": "^0.5.7",
+    "webpack-manifest-plugin": "^1.1.0"
   }
 }


### PR DESCRIPTION
#### Changes
This pull request merges in some customizations we had made to our Webpack config in Phoenix Next:

#️⃣ Adds a hash to script & style filenames (e.g. `app-e403528026001172451e.js` instead of `app.js`), and outputs a `rev-manifest.json` for Laravel or other frameworks to be able to load those in server-side templates.

↘️ Adds [Lodash's webpack plugin](https://github.com/lodash/lodash-webpack-plugin), which alongside [their Babel plugin](https://github.com/lodash/babel-plugin-lodash) reduces our build size in Phoenix Next by about 100kb without any need for micro-optimizations from developers.

Not going to release this just yet since I want to try to fit in a few more breaking changes, but it is ready for review so I don't make an extra-hefty pull request. 😉
