### PR TITLE
Update to use Webpack 2.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # webpack-config
 
-This is our shared [Webpack](http://webpack.github.io) config used for front-end projects at DoSomething.org. It builds JavaScript with [Babel](https://babeljs.io), SCSS with [LibSass](http://sass-lang.com/libsass), and CSS with [Autoprefixer](https://github.com/postcss/autoprefixer) and [CSS-MQPacker](https://github.com/hail2u/node-css-mqpacker). It is also configured to hash static asset filenames, or bundle as Data URIs if small enough.
+This is our shared [Webpack](http://webpack.github.io) config used for front-end projects at DoSomething.org. It compiles JavaScript with [Babel](https://babeljs.io), SCSS with [LibSass](http://sass-lang.com/libsass), and CSS with [Autoprefixer](https://github.com/postcss/autoprefixer) and [CSS-MQPacker](https://github.com/hail2u/node-css-mqpacker). It is also configured to add hashes to filenames for easy caching, and inlines images and fonts as Data URIs if small enough.
 
 ### Getting Started
 Install this package and Webpack via NPM: 
@@ -15,7 +15,8 @@ Add some scripts to your `package.json`:
 {
   // ...
   "scripts": {
-    "start": "webpack",
+    "start": "NODE_ENV=development webpack --watch",
+    "build:dev": "NODE_ENV=development webpack",
     "build": "NODE_ENV=production webpack",
   }
 }
@@ -25,20 +26,23 @@ Create a `webpack.config.js` in your project directory, and set it up like so:
 
 ```js
 var webpack = require('webpack');
-var config = require('@dosomething/webpack-config');
+var configure = require('@dosomething/webpack-config');
 
-module.exports = config({
+module.exports = configure({
   entry: {
     // Add your bundles here, so in this case
-    // ./src/app.js ==> ./dist/app.js
-    'app': './src/app.js'
+    // ./src/app.js ==> ./dist/app-[hash].js
+    app: './src/app.js'
   }
+
+  // Override any other Webpack settings here!
+  // see: https://webpack.js.org/configuration/
 });
 ```
 
-Now you can run `npm start` to build with source maps and watch for changes, and `npm run build` to build optimized assets for production! If you need to further customize your build, you can always directly modify the object returned by the `config()` function!
+Now you can run `npm start` to build with source maps and watch for changes, and `npm run build` to build optimized assets for production! If you need to further customize your build, you can pass any overrides in to the configure function.
 
 ### License
-&copy;2016 DoSomething.org. @dosomething/webpack-config is free software, and may be redistributed under the
+&copy;2017 DoSomething.org. @dosomething/webpack-config is free software, and may be redistributed under the
 terms specified in the [LICENSE](https://github.com/DoSomething/webpack-config/blob/master/LICENSE) file. The
 name and logo for DoSomething.org are trademarks of Do Something, Inc and may not be used without permission.

--- a/index.js
+++ b/index.js
@@ -43,10 +43,10 @@ const config = {
             { test: /\.(png|jpe?g|eot|gif|woff2?|svg|ttf)$/, use: ['url-loader?limit=8192'] },
 
             // Bundle CSS stylesheets and process with PostCSS, extract to single CSS file per bundle.
-            { test: /\.css$/, loader: ExtractTextPlugin.extract(['css-loader?sourceMap', postcss]) },
+            { test: /\.css$/, use: ExtractTextPlugin.extract(['css-loader?sourceMap', postcss]) },
 
             // Bundle SCSS stylesheets (processed with LibSass & PostCSS), extract to single CSS file per bundle.
-            { test: /\.scss$/, loader: ExtractTextPlugin.extract(['css-loader?sourceMap', postcss, 'sass-loader?sourceMap']) }
+            { test: /\.scss$/, use: ExtractTextPlugin.extract(['css-loader?sourceMap', postcss, 'sass-loader?sourceMap']) }
         ]
     },
     plugins: [

--- a/index.js
+++ b/index.js
@@ -73,7 +73,12 @@ var config = {
         new ManifestPlugin({
           fileName: 'rev-manifest.json',
         }),
-    ]
+    ],
+
+    stats: {
+        // Don't print noisy output for extracted CSS children.
+        children: false
+    },
 };
 
 if(process.env.NODE_ENV === 'production') {

--- a/index.js
+++ b/index.js
@@ -1,8 +1,3 @@
-/**
- * This is DoSomething.org's shared Webpack config for
- * building JavaScript, SCSS, and other front-end assets.
- */
-
 var webpack = require('webpack');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var LodashModuleReplacementPlugin = require('lodash-webpack-plugin');
@@ -12,6 +7,27 @@ var assign = require('lodash/assign');
 var path = require('path');
 var fs = require('fs');
 
+// PostCSS loader w/ options.
+const postcss = {
+    loader: 'postcss-loader',
+    options: {
+        plugins: function() {
+            return [
+                // Automatically add vendor prefixes using Autoprefixer.
+                require('autoprefixer')({
+                    browsers: ['last 4 versions', 'Firefox ESR', 'Opera 12.1'],
+                }),
+
+                // Combine media queries using CSS-MQPacker.
+                require('css-mqpacker')()
+            ];
+        }
+    }
+
+}
+
+// Default Webpack configuration
+// @see: https://webpack.js.org/configuration/
 var config = {
     entry: {
         // ...
@@ -24,28 +40,17 @@ var config = {
     module: {
         loaders: [
             // Bundle JavaScript, and transform to ES5 using Babel.
-            { test: /\.js$/, exclude: /node_modules/, loader: 'babel' },
+            { test: /\.js$/, exclude: /node_modules/, use: ['babel-loader'] },
 
             // Bundle static assets, either hashing filename or inlining into bundle if under 8KB
-            { test: /\.(png|jpe?g|eot|gif|woff2?|svg|ttf)$/, loader: 'url?limit=8192' },
+            { test: /\.(png|jpe?g|eot|gif|woff2?|svg|ttf)$/, use: ['url-loader?limit=8192'] },
 
             // Bundle CSS stylesheets and process with PostCSS, extract to single CSS file per bundle.
-            { test: /\.css$/, loader: ExtractTextPlugin.extract('css?sourceMap!postcss') },
+            { test: /\.css$/, loader: ExtractTextPlugin.extract(['css-loader', postcss]) },
 
             // Bundle SCSS stylesheets (processed with LibSass & PostCSS), extract to single CSS file per bundle.
-            { test: /\.scss$/, loader: ExtractTextPlugin.extract('css?sourceMap!postcss!sass?sourceMap') }
+            { test: /\.scss$/, loader: ExtractTextPlugin.extract(['css-loader', postcss, 'sass-loader']) }
         ]
-    },
-    postcss: function() {
-        return [
-            // Automatically add vendor prefixes using Autoprefixer.
-            require('autoprefixer')({
-                browsers: ['last 4 versions', 'Firefox ESR', 'Opera 12.1'],
-            }),
-
-            // Combine media queries using CSS-MQPacker.
-            require('css-mqpacker')()
-        ];
     },
     plugins: [
         // Make NODE_ENV accessible from within client scripts (for conditional dev/prod builds).
@@ -57,7 +62,7 @@ var config = {
 
         // Extract all stylesheets referenced in each bundle into a single CSS file.
         new ExtractTextPlugin('[name]-[hash].css'),
-      
+
         // Optimize ordering of modules for better minification
         new webpack.optimize.OccurrenceOrderPlugin,
 
@@ -84,25 +89,16 @@ if(process.env.NODE_ENV === 'production') {
       })
     )
 } else {
-    // Enable inline source maps when in development.
-    config.devtool = '#inline-source-map';
+    // Enable source maps when in development.
+    // @see: https://git.io/vSAY0
+    config.devtool = '#cheap-module-source-map';
 
     // Instruct Webpack to watch for changes & rebuild.
     config.watch = true;
 }
 
 var configurator = function(options) {
-    var c = defaults(config, options);
-
-    // If we're running in NPM 2.x, we need to tell Webpack to check this
-    // package's `node_modules` when resolving loaders in addition to the
-    // client's `node_modules` (which is the default behavior).
-    assign(config, { resolveLoader: { modulesDirectories: [
-        path.resolve('./node_modules'),
-        path.join(__dirname, 'node_modules')
-    ] } });
-
-    return c;
+    return defaults(config, options);
 };
 
 module.exports = configurator;

--- a/index.js
+++ b/index.js
@@ -51,11 +51,7 @@ const config = {
     },
     plugins: [
         // Make NODE_ENV accessible from within client scripts (for conditional dev/prod builds).
-        new webpack.DefinePlugin({
-            'process.env': {
-                'NODE_ENV': JSON.stringify(process.env.NODE_ENV)
-            }
-        }),
+        new webpack.EnvironmentPlugin(['NODE_ENV']),
 
         // Extract all stylesheets referenced in each bundle into a single CSS file.
         new ExtractTextPlugin('[name]-[hash].css'),

--- a/index.js
+++ b/index.js
@@ -2,10 +2,7 @@ var webpack = require('webpack');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var LodashModuleReplacementPlugin = require('lodash-webpack-plugin');
 var ManifestPlugin = require('webpack-manifest-plugin');
-var defaults = require('lodash/defaultsDeep');
-var assign = require('lodash/assign');
-var path = require('path');
-var fs = require('fs');
+var merge = require('webpack-merge');
 
 // PostCSS loader w/ options.
 const postcss = {
@@ -46,10 +43,10 @@ var config = {
             { test: /\.(png|jpe?g|eot|gif|woff2?|svg|ttf)$/, use: ['url-loader?limit=8192'] },
 
             // Bundle CSS stylesheets and process with PostCSS, extract to single CSS file per bundle.
-            { test: /\.css$/, loader: ExtractTextPlugin.extract(['css-loader', postcss]) },
+            { test: /\.css$/, loader: ExtractTextPlugin.extract(['css-loader?sourceMap', postcss]) },
 
             // Bundle SCSS stylesheets (processed with LibSass & PostCSS), extract to single CSS file per bundle.
-            { test: /\.scss$/, loader: ExtractTextPlugin.extract(['css-loader', postcss, 'sass-loader']) }
+            { test: /\.scss$/, loader: ExtractTextPlugin.extract(['css-loader?sourceMap', postcss, 'sass-loader?sourceMap']) }
         ]
     },
     plugins: [
@@ -97,13 +94,10 @@ if(process.env.NODE_ENV === 'production') {
     // Enable source maps when in development.
     // @see: https://git.io/vSAY0
     config.devtool = '#cheap-module-source-map';
-
-    // Instruct Webpack to watch for changes & rebuild.
-    config.watch = true;
 }
 
 var configurator = function(options) {
-    return defaults(config, options);
+    return merge(config, options);
 };
 
 module.exports = configurator;

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
-var webpack = require('webpack');
-var ExtractTextPlugin = require('extract-text-webpack-plugin');
-var LodashModuleReplacementPlugin = require('lodash-webpack-plugin');
-var ManifestPlugin = require('webpack-manifest-plugin');
-var merge = require('webpack-merge');
+const webpack = require('webpack');
+const ExtractTextPlugin = require('extract-text-webpack-plugin');
+const LodashModuleReplacementPlugin = require('lodash-webpack-plugin');
+const ManifestPlugin = require('webpack-manifest-plugin');
+const merge = require('webpack-merge');
 
 // PostCSS loader w/ options.
 const postcss = {
@@ -25,7 +25,7 @@ const postcss = {
 
 // Default Webpack configuration
 // @see: https://webpack.js.org/configuration/
-var config = {
+const config = {
     entry: {
         // ...
     },
@@ -74,31 +74,39 @@ var config = {
 
     stats: {
         // Don't print noisy output for extracted CSS children.
-        children: false
+        children: false,
     },
 };
 
-if(process.env.NODE_ENV === 'production') {
-    // In production, minify our output with UglifyJS
-    config.plugins.push(
+
+// Production build settings:
+const production = {
+  plugins: [
+      // Minify produciton builds & remove logging.
       new webpack.optimize.UglifyJsPlugin({
           compress: {
               warnings: false,
               drop_console: true,
               drop_debugger: true,
-              dead_code: true
+              dead_code: true,
           }
-      })
-    )
-} else {
-    // Enable source maps when in development.
-    // @see: https://git.io/vSAY0
-    config.devtool = '#cheap-module-source-map';
-}
-
-var configurator = function(options) {
-    return merge(config, options);
+      }),
+  ],
 };
 
-module.exports = configurator;
+// Development build settings:
+const development = {
+    // Enable source maps when in development.
+    // @see: https://git.io/vSAY0
+    devtool: '#cheap-module-source-map',
+};
+
+// Export a `configure()` function for applications to
+// import & extend in their `webpack.config.js` files.
+module.exports = function(options) {
+    const isProductionBuild = process.env.NODE_ENV === 'production';
+    const environmentConfig = isProductionBuild ? production : development;
+
+    return merge(config, environmentConfig, options);
+};
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "@dosomething/webpack-config",
   "version": "1.1.2",
   "description": "Shared Webpack config for DoSomething.org projects.",
+  "engines": {
+    "node": ">= 4.0.0", 
+    "npm": ">= 3.0.0"
+  },
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "url-loader": "^0.5.8",
     "webpack": "^2.4.1",
     "webpack-dev-server": "^2.4.2",
-    "webpack-manifest-plugin": "^1.1.0"
+    "webpack-manifest-plugin": "^1.1.0",
+    "webpack-merge": "^4.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,24 +8,22 @@
   },
   "author": "David Furnes <dfurnes@dosomething.org>",
   "license": "MIT",
-  "peerDependencies": {
-    "webpack": "^1.12.14",
-    "webpack-dev-server": "^1.14.1"
-  },
   "dependencies": {
-    "autoprefixer": "^6.3.3",
-    "babel-core": "^6.7.2",
-    "babel-loader": "^6.2.4",
-    "css-loader": "^0.23.1",
+    "autoprefixer": "^6.7.7",
+    "babel-core": "^6.24.1",
+    "babel-loader": "v7.0.0-beta.1",
+    "css-loader": "~0.28.0",
     "css-mqpacker": "^4.0.1",
-    "extract-text-webpack-plugin": "^1.0.1",
-    "file-loader": "^0.8.5",
-    "lodash": "^4.6.1",
+    "extract-text-webpack-plugin": "^2.1.0",
+    "file-loader": "^0.11.1",
+    "lodash": "^4.17.4",
     "lodash-webpack-plugin": "^0.11.2",
-    "node-sass": "^3.4.2",
-    "postcss-loader": "^0.8.2",
-    "sass-loader": "^3.2.0",
-    "url-loader": "^0.5.7",
+    "node-sass": "^4.5.2",
+    "postcss-loader": "^1.3.3",
+    "sass-loader": "^6.0.3",
+    "url-loader": "^0.5.8",
+    "webpack": "^2.4.1",
+    "webpack-dev-server": "^2.4.2",
     "webpack-manifest-plugin": "^1.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.2",
   "description": "Shared Webpack config for DoSomething.org projects.",
   "engines": {
-    "node": ">= 4.0.0", 
+    "node": ">= 4.0.0",
     "npm": ">= 3.0.0"
   },
   "main": "index.js",


### PR DESCRIPTION
#### Changes
This pull request updates our config for Webpack 2. I've also made a few tiny changes:
 - Development builds now only watch for changes if `--watch` is specified in the script step. This allows us to have both a `npm start` that watches for changes and an `npm run build:dev` for one-off development builds.
 - Silences those frustrating `Child extract-text-webpack-plugin: + 2 hidden modules` messages.
 - Uses `webpack-merge` for more elegant config overrides.

Once this is merged, I'll publish as a major 2.0 release.

🛠