### PR TITLE
Remove Lodash webpack plugin.

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,9 +59,6 @@ const config = {
         // Optimize ordering of modules for better minification
         new webpack.optimize.OccurrenceOrderPlugin,
 
-        // Optimize Lodash references for smaller builds.
-        new LodashModuleReplacementPlugin,
-
         // Create asset manifest (allowing Laravel or other apps to get hashed asset names).
         new ManifestPlugin({
           fileName: 'rev-manifest.json',

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "extract-text-webpack-plugin": "^2.1.0",
     "file-loader": "^0.11.1",
     "lodash": "^4.17.4",
-    "lodash-webpack-plugin": "^0.11.2",
     "node-sass": "^4.5.2",
     "postcss-loader": "^1.3.3",
     "sass-loader": "^6.0.3",


### PR DESCRIPTION
### Changes
This fixes an issue where `_.get` was unexpectedly returning `undefined` because of the `paths` optimization in [LodashWebpackPlugin](https://github.com/lodash/lodash-webpack-plugin). It turns out this optimizes a bit more aggressively than I thought when I added it – it will remove support for all the features in [this list](https://github.com/lodash/lodash-webpack-plugin#feature-sets) unless you specifically opt in, which is a bit too much cognitive overhead I think.

Plus, most of our space savings came from adding [babel-plugin-lodash](https://www.npmjs.com/package/babel-plugin-lodash) to our [Babel config](https://github.com/DoSomething/babel-config) (which optimizes our imports), so enabling this only adds ~10kb to the final builds.

