### PR TITLE
Pin sass-loader version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "lodash": "^4.17.4",
     "node-sass": "^4.5.2",
     "postcss-loader": "^1.3.3",
-    "sass-loader": "^6.0.3",
+    "sass-loader": "6.0.3",
     "url-loader": "^0.5.8",
     "webpack": "^2.4.1",
     "webpack-dev-server": "^2.4.2",


### PR DESCRIPTION
There's [a bug](https://git.io/v9PsY) in the [latest `sass-loader` release](https://github.com/webpack-contrib/sass-loader/releases/tag/v6.0.4). For now, let's pin to the previous working version.