### PR TITLE
Unpin sass-loader version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "lodash": "^4.17.4",
     "node-sass": "^4.5.2",
     "postcss-loader": "^1.3.3",
-    "sass-loader": "6.0.3",
+    "sass-loader": "^6.0.5",
     "url-loader": "^0.5.8",
     "webpack": "^2.4.1",
     "webpack-dev-server": "^2.4.2",


### PR DESCRIPTION
The issue with scoped imports in `sass-loader` has been [fixed](https://git.io/v9PsY), so let's unpin this! 📌 

References #8.