### PR TITLE
Enable scope hoisting.

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,6 +63,9 @@ const config = {
         new ManifestPlugin({
           fileName: 'rev-manifest.json',
         }),
+
+        // Enable scope hoisting for more efficient builds.
+        new webpack.optimize.ModuleConcatenationPlugin(),
     ],
 
     stats: {
@@ -75,7 +78,7 @@ const config = {
 // Production build settings:
 const production = {
   plugins: [
-      // Minify produciton builds & remove logging.
+      // Minify production builds & remove logging.
       new webpack.optimize.UglifyJsPlugin({
           compress: {
               warnings: false,


### PR DESCRIPTION
### Changes
This pull request enables [scope hoisting](https://webpack.js.org/plugins/module-concatenation-plugin/) with Webpack 3. (Pending an update in our Babel config to _not_ compile ES6 modules to CommonJS so Webpack can be smart about them.)