### PR TITLE
Hash chunks independently for more fine-grained caching.

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ const baseConfig = {
     },
 
     output: {
-        filename: '[name]-[hash].js',
+        filename: '[name]-[chunkhash].js',
         path: 'dist',
     },
 
@@ -55,7 +55,7 @@ const baseConfig = {
     plugins: [
         // Extract all stylesheets referenced in each bundle into a single CSS file.
         new MiniCssExtractPlugin({
-          filename: "[name]-[hash].css",
+          filename: "[name]-[chunkhash].css",
           chunkFilename: "[id].css"
         }),
 

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ const postcss = {
             return [
                 // Automatically add vendor prefixes using Autoprefixer.
                 require('autoprefixer')({
-                    browsers: ['last 4 versions', 'Firefox ESR', 'Opera 12.1'],
+                    browsers: ['last 2 versions', 'Firefox ESR', 'not dead'],
                 }),
 
                 // Combine media queries using CSS-MQPacker.


### PR DESCRIPTION
Adjusts our supported browsers to match [our Babel config](https://github.com/DoSomething/babel-config/blob/516342842a4e30bac2d37cab31f9707836ea3e6f/index.js#L9) and hashes individual chunks, rather than the _whole_ entry point. This allows us to keep a vendor bundle with long-term caching even while we make more frequent changes to the application itself.