### PR TITLE
Removing MQPacker due to wonkiness with CSS Grid.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # webpack-config
 
-This is our shared [Webpack](http://webpack.github.io) config used for front-end projects at DoSomething.org. It compiles JavaScript with [Babel](https://babeljs.io), SCSS with [LibSass](http://sass-lang.com/libsass), and CSS with [Autoprefixer](https://github.com/postcss/autoprefixer) and [CSS-MQPacker](https://github.com/hail2u/node-css-mqpacker). It is also configured to add hashes to filenames for easy caching, and inlines images and fonts as Data URIs if small enough.
+This is our shared [Webpack](http://webpack.github.io) config used for front-end projects at DoSomething.org. It compiles JavaScript with [Babel](https://babeljs.io), SCSS with [LibSass](http://sass-lang.com/libsass), and CSS with [Autoprefixer](https://github.com/postcss/autoprefixer). It is also configured to add hashes to filenames for easy caching, and inlines images and fonts as Data URIs if small enough.
 
 ### Getting Started
 Install this package and Webpack via NPM: 

--- a/index.js
+++ b/index.js
@@ -13,9 +13,6 @@ const postcss = {
             return [
                 // Automatically add vendor prefixes using Autoprefixer.
                 require('autoprefixer')(),
-
-                // Combine media queries using CSS-MQPacker.
-                require('css-mqpacker')(),
             ];
         }
     }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "babel-loader": "^8.0.5",
     "clean-webpack-plugin": "^2.0.2",
     "css-loader": "^2.1.1",
-    "css-mqpacker": "^7.0.0",
     "file-loader": "^3.0.1",
     "lodash": "^4.17.14",
     "mini-css-extract-plugin": "^0.6.0",


### PR DESCRIPTION
This PR removes the use of MQPacker package from our Webpack configuration. I noticed some wonky behavior with CSS Grid and media queries firing oddly and unexpectedly. With help from @DFurnes we saw that disabling the use of MQPacker would fix the issue. It seems like when the package is packing media queries together it's having some difficulty with CSS Grid rules.

We had assumed that by removing the use of MQPacker, it would end up with a larger minified CSS size, which it did by a negligible amount, but more surprisingly it resulted in a smaller GZIP CSS size! 

Turns out it's better to not pack media queries together if we're ensuring we GZIP our CSS. 💡 

<img width="554" alt="MQPacker GZIP Data" src="https://user-images.githubusercontent.com/105849/62710085-a2594a00-b9c4-11e9-862d-e08a5aaeac68.png">
